### PR TITLE
chore: unify MIT LICENSE and update copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Billy Richardson (richardson.dev, richardsondev)
+Copyright (c) 2023-2026 Billy Richardson (richardson.dev, richardsondev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR normalizes and updates the MIT license file.

**Changes**
- Replace license text with canonical MIT template
- Ensure filename: `LICENSE`
- Notice: `Copyright (c) 2023-2026 Billy Richardson (richardson.dev, richardsondev)`